### PR TITLE
[BQ-477]: Remove 401 status from swagger for public/institutions EP

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ mkdir -p $BUILD_DIR
 
 swagger generate client -f ./swagger.json -A ./basiq-"$RELEASE_VERSION" -t "$BUILD_DIR"
 
-go test ./test/...
+go test ./test/... -count 1
 
 if [ $? -eq 0 ]; then
   echo "Done generating $RELEASE_VERSION swagger sdk. Check $BUILD_DIR directory."

--- a/test/institutions/responses/getPublicInstitutions.json
+++ b/test/institutions/responses/getPublicInstitutions.json
@@ -2,7 +2,7 @@
   "data": [],
   "totalCount": 0,
   "links": {
-    "self": "https://au-api.basiq.io/institutions"
+    "self": "https://au-api.basiq.io/public/institutions"
   },
   "type": "list"
 }


### PR DESCRIPTION
[Problem]
Endpoint "GET /public/institutions" now have /public/institutions self URI.

[Solution]
Update test fixture for /public/institutions test

[Testing]
integration test